### PR TITLE
Add identifiers as nodes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,13 +6,24 @@ ADD . /sections-rw-neo4j/
 RUN apk add --update bash \
   && apk --update add git bzr \
   && apk --update add go \
+  && cd sections-rw-neo4j \
+  && git fetch origin 'refs/tags/*:refs/tags/*' \
+  && BUILDINFO_PACKAGE="github.com/Financial-Times/service-status-go/buildinfo." \
+  && VERSION="version=$(git describe --tag --always 2> /dev/null)" \
+  && DATETIME="dateTime=$(date -u +%Y%m%d%H%M%S)" \
+  && REPOSITORY="repository=$(git config --get remote.origin.url)" \
+  && REVISION="revision=$(git rev-parse HEAD)" \
+  && BUILDER="builder=$(go version)" \
+  && LDFLAGS="-X '"${BUILDINFO_PACKAGE}$VERSION"' -X '"${BUILDINFO_PACKAGE}$DATETIME"' -X '"${BUILDINFO_PACKAGE}$REPOSITORY"' -X '"${BUILDINFO_PACKAGE}$REVISION"' -X '"${BUILDINFO_PACKAGE}$BUILDER"'" \
+  && cd .. \
   && export GOPATH=/gopath \
   && REPO_PATH="github.com/Financial-Times/sections-rw-neo4j" \
   && mkdir -p $GOPATH/src/${REPO_PATH} \
   && mv sections-rw-neo4j/* $GOPATH/src/${REPO_PATH} \
   && cd $GOPATH/src/${REPO_PATH} \
   && go get -t ./... \
-  && go build \
+  && echo ${LDFLAGS} \
+  && go build -ldflags="${LDFLAGS}" \
   && mv sections-rw-neo4j /app \
   && apk del go git bzr \
   && rm -rf $GOPATH /var/cache/apk/*

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ NB: the default batchSize is much higher than the throughput the instance data i
 ## Endpoints
 /sections/{uuid}
 ### PUT
-The only mandatory field is the uuid, and the uuid in the body must match the one used on the path.
+"The only mandatory fields are the uuid, the prefLabel and the alternativeIdentifier uuids (because the uuid is also listed in the alternativeIdentifier uuids list)."
 
 Every request results in an attempt to update that section: unlike with GraphDB there is no check on whether the section already exists and whether there are any changes between what's there and what's being written. We just do a MERGE which is Neo4j for create if not there, update if it is there.
 
@@ -50,7 +50,9 @@ We run queries in batches. If a batch fails, all failing requests will get a 500
 Invalid json body input, or uuids that don't match between the path and the body will result in a 400 bad request response.
 
 Example:
-`curl -XPUT -H "X-Request-Id: 123" -H "Content-Type: application/json" localhost:8080/sections/bba39990-c78d-3629-ae83-808c333c6dbc --data '{"uuid":"bba39990-c78d-3629-ae83-808c333c6dbc","canonicalName":"Metals Markets","tmeIdentifier":"MTE3-U3ViamVjdHM=","type":"Section"}'`
+`curl -XPUT -H "X-Request-Id: 123" -H "Content-Type: application/json" localhost:8080/topics/bba39990-c78d-3629-ae83-808c333c6dbc --data '{"uuid":"bba39990-c78d-3629-ae83-808c333c6dbc","prefLabel":"Metals Markets", "alternativeIdentifiers":{"TME":["MTE3-U3ViamVjdHM="],"uuids": ["bba39990-c78d-3629-ae83-808c333c6dbc","6a2a0170-6afa-4bcc-b427-430268d2ac50"],"factsetIdentifier":"asdasd","leiCode":"baz","type":"Topic"}}'`
+
+The type field is not currently validated - instead, the Topic Writer writes type Topic and its parent types (Concept and Thing) as labels for the Topic.
 
 ### GET
 The internal read should return what got written

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ We run queries in batches. If a batch fails, all failing requests will get a 500
 Invalid json body input, or uuids that don't match between the path and the body will result in a 400 bad request response.
 
 Example:
-`curl -XPUT -H "X-Request-Id: 123" -H "Content-Type: application/json" localhost:8080/topics/bba39990-c78d-3629-ae83-808c333c6dbc --data '{"uuid":"bba39990-c78d-3629-ae83-808c333c6dbc","prefLabel":"Metals Markets", "alternativeIdentifiers":{"TME":["MTE3-U3ViamVjdHM="],"uuids": ["bba39990-c78d-3629-ae83-808c333c6dbc","6a2a0170-6afa-4bcc-b427-430268d2ac50"],"factsetIdentifier":"asdasd","leiCode":"baz","type":"Topic"}}'`
+`curl -XPUT -H "X-Request-Id: 123" -H "Content-Type: application/json" localhost:8080/topics/bba39990-c78d-3629-ae83-808c333c6dbc --data '{"uuid":"bba39990-c78d-3629-ae83-808c333c6dbc","prefLabel":"Metals Markets", "alternativeIdentifiers":{"TME":["MTE3-U3ViamVjdHM="],"uuids": ["bba39990-c78d-3629-ae83-808c333c6dbc","6a2a0170-6afa-4bcc-b427-430268d2ac50"],"type":"Topic"}}'`
 
 The type field is not currently validated - instead, the Topic Writer writes type Topic and its parent types (Concept and Thing) as labels for the Topic.
 

--- a/sections/model.go
+++ b/sections/model.go
@@ -1,7 +1,7 @@
 package sections
 
 type Section struct {
-	UUID          string `json:"uuid"`
+	UUID                   string                 `json:"uuid"`
 	PrefLabel              string                 `json:"prefLabel"`
 	AlternativeIdentifiers alternativeIdentifiers `json:"alternativeIdentifiers"`
 	Types                  []string               `json:"types,omitempty"`

--- a/sections/model.go
+++ b/sections/model.go
@@ -8,17 +8,13 @@ type Section struct {
 }
 
 type alternativeIdentifiers struct {
-	TME               []string `json:"TME,omitempty"`
-	FactsetIdentifier string   `json:"factsetIdentifier,omitempty"`
-	LeiCode           string   `json:"leiCode,omitempty"`
-	UUIDS             []string `json:"uuids"`
+	TME   []string `json:"TME,omitempty"`
+	UUIDS []string `json:"uuids"`
 }
 
 const (
-	factsetIdentifierLabel = "FactsetIdentifier"
-	leiIdentifierLabel     = "LegalEntityIdentifier"
-	tmeIdentifierLabel     = "TMEIdentifier"
-	uppIdentifierLabel     = "UPPIdentifier"
+	tmeIdentifierLabel = "TMEIdentifier"
+	uppIdentifierLabel = "UPPIdentifier"
 )
 
 type SectionLink struct {

--- a/sections/model.go
+++ b/sections/model.go
@@ -2,10 +2,24 @@ package sections
 
 type Section struct {
 	UUID          string `json:"uuid"`
-	CanonicalName string `json:"canonicalName"`
-	TmeIdentifier string `json:"tmeIdentifier,omitempty"`
-	Type          string `json:"type,omitempty"`
+	PrefLabel              string                 `json:"prefLabel"`
+	AlternativeIdentifiers alternativeIdentifiers `json:"alternativeIdentifiers"`
+	Types                  []string               `json:"types,omitempty"`
 }
+
+type alternativeIdentifiers struct {
+	TME               []string `json:"TME,omitempty"`
+	FactsetIdentifier string   `json:"factsetIdentifier,omitempty"`
+	LeiCode           string   `json:"leiCode,omitempty"`
+	UUIDS             []string `json:"uuids"`
+}
+
+const (
+	factsetIdentifierLabel = "FactsetIdentifier"
+	leiIdentifierLabel     = "LegalEntityIdentifier"
+	tmeIdentifierLabel     = "TMEIdentifier"
+	uppIdentifierLabel     = "UPPIdentifier"
+)
 
 type SectionLink struct {
 	ApiUrl string `json:"apiUrl"`

--- a/sections/sections_service.go
+++ b/sections/sections_service.go
@@ -2,7 +2,7 @@ package sections
 
 import (
 	"encoding/json"
-
+	"fmt"
 	"github.com/Financial-Times/neo-utils-go/neoutils"
 	"github.com/jmcvetta/neoism"
 )
@@ -23,16 +23,22 @@ func (s service) Initialise() error {
 		"Thing":   "uuid",
 		"Concept": "uuid",
 		"Classification": "uuid",
-		"Section":   "uuid"})
+		"Section":   "uuid",
+		"FactsetIdentifier": "value",
+		"TMEIdentifier":     "value",
+		"UPPIdentifier":     "value"})
 }
 
 func (s service) Read(uuid string) (interface{}, bool, error) {
 	results := []Section{}
 
 	query := &neoism.CypherQuery{
-		Statement: `MATCH (n:Section {uuid:{uuid}}) return n.uuid
-		as uuid, n.canonicalName as canonicalName,
-		n.tmeIdentifier as tmeIdentifier`,
+		Statement: `MATCH (n:Section {uuid:{uuid}})
+OPTIONAL MATCH (upp:UPPIdentifier)-[:IDENTIFIES]->(n)
+OPTIONAL MATCH (fs:FactsetIdentifier)-[:IDENTIFIES]->(n)
+OPTIONAL MATCH (tme:TMEIdentifier)-[:IDENTIFIES]->(n)
+OPTIONAL MATCH (lei:LegalEntityIdentifier)-[:IDENTIFIES]->(n)
+return distinct n.uuid as uuid, n.prefLabel as prefLabel, labels(n) as types, {uuids:collect(distinct upp.value), TME:collect(distinct tme.value), factsetIdentifier:fs.value, leiCode:lei.value} as alternativeIdentifiers`,
 		Parameters: map[string]interface{}{
 			"uuid": uuid,
 		},
@@ -54,22 +60,20 @@ func (s service) Read(uuid string) (interface{}, bool, error) {
 
 func (s service) Write(thing interface{}) error {
 
-	sub := thing.(Section)
+	section := thing.(Section)
 
-	params := map[string]interface{}{
-		"uuid": sub.UUID,
+	//cleanUP all the previous IDENTIFIERS referring to that uuid
+	deletePreviousIdentifiersQuery := &neoism.CypherQuery{
+		Statement: `MATCH (t:Thing {uuid:{uuid}})
+		OPTIONAL MATCH (t)<-[iden:IDENTIFIES]-(i)
+		DELETE iden, i`,
+		Parameters: map[string]interface{}{
+			"uuid": section.UUID,
+		},
 	}
-
-	if sub.CanonicalName != "" {
-		params["canonicalName"] = sub.CanonicalName
-		params["prefLabel"] = sub.CanonicalName
-	}
-
-	if sub.TmeIdentifier != "" {
-		params["tmeIdentifier"] = sub.TmeIdentifier
-	}
-
-	query := &neoism.CypherQuery{
+	
+	//create-update node for SECTION
+	createSectionQuery := &neoism.CypherQuery{
 		Statement: `MERGE (n:Thing {uuid: {uuid}})
 					set n={allprops}
 					set n :Concept
@@ -77,29 +81,69 @@ func (s service) Write(thing interface{}) error {
 					set n :Section
 		`,
 		Parameters: map[string]interface{}{
-			"uuid":     sub.UUID,
-			"allprops": params,
+			"uuid": section.UUID,
+			"allprops": map[string]interface{}{
+				"uuid":      section.UUID,
+				"prefLabel": section.PrefLabel,
+			},
 		},
 	}
 
-	return s.cypherRunner.CypherBatch([]*neoism.CypherQuery{query})
+	queryBatch := []*neoism.CypherQuery{deletePreviousIdentifiersQuery, createSectionQuery}
 
+	//ADD all the IDENTIFIER nodes and IDENTIFIES relationships
+	if section.AlternativeIdentifiers.FactsetIdentifier != "" {
+		factsetIdentifierQuery := createNewIdentifierQuery(section.UUID, factsetIdentifierLabel, section.AlternativeIdentifiers.FactsetIdentifier)
+		queryBatch = append(queryBatch, factsetIdentifierQuery)
+	}
+
+	if section.AlternativeIdentifiers.LeiCode != "" {
+		leiCodeIdentifierQuery := createNewIdentifierQuery(section.UUID, leiIdentifierLabel, section.AlternativeIdentifiers.LeiCode)
+		queryBatch = append(queryBatch, leiCodeIdentifierQuery)
+	}
+
+	for _, alternativeUUID := range section.AlternativeIdentifiers.TME {
+		alternativeIdentifierQuery := createNewIdentifierQuery(section.UUID, tmeIdentifierLabel, alternativeUUID)
+		queryBatch = append(queryBatch, alternativeIdentifierQuery)
+	}
+
+	for _, alternativeUUID := range section.AlternativeIdentifiers.UUIDS {
+		alternativeIdentifierQuery := createNewIdentifierQuery(section.UUID, uppIdentifierLabel, alternativeUUID)
+		queryBatch = append(queryBatch, alternativeIdentifierQuery)
+	}
+
+	return s.cypherRunner.CypherBatch(queryBatch)
+
+}
+
+func createNewIdentifierQuery(uuid string, identifierLabel string, identifierValue string) *neoism.CypherQuery {
+	statementTemplate := fmt.Sprintf(`MERGE (t:Thing {uuid:{uuid}})
+					CREATE (i:Identifier {value:{value}})
+					MERGE (t)<-[:IDENTIFIES]-(i)
+					set i : %s `, identifierLabel)
+	query := &neoism.CypherQuery{
+		Statement: statementTemplate,
+		Parameters: map[string]interface{}{
+			"uuid":  uuid,
+			"value": identifierValue,
+		},
+	}
+	return query
 }
 
 func (s service) Delete(uuid string) (bool, error) {
 	clearNode := &neoism.CypherQuery{
 		Statement: `
 			MATCH (t:Thing {uuid: {uuid}})
+			OPTIONAL MATCH (t)<-[iden:IDENTIFIES]-(i:Identifier)
 			REMOVE t:Concept
 			REMOVE t:Classification
 			REMOVE t:Section
-			SET t={props}
+			DELETE iden, i
+			SET t = {uuid:{uuid}}
 		`,
 		Parameters: map[string]interface{}{
 			"uuid": uuid,
-			"props": map[string]interface{}{
-				"uuid": uuid,
-			},
 		},
 		IncludeStats: true,
 	}

--- a/sections/sections_service.go
+++ b/sections/sections_service.go
@@ -24,7 +24,6 @@ func (s service) Initialise() error {
 		"Concept":           "uuid",
 		"Classification":    "uuid",
 		"Section":           "uuid",
-		"FactsetIdentifier": "value",
 		"TMEIdentifier":     "value",
 		"UPPIdentifier":     "value"})
 }
@@ -35,10 +34,8 @@ func (s service) Read(uuid string) (interface{}, bool, error) {
 	query := &neoism.CypherQuery{
 		Statement: `MATCH (n:Section {uuid:{uuid}})
 OPTIONAL MATCH (upp:UPPIdentifier)-[:IDENTIFIES]->(n)
-OPTIONAL MATCH (fs:FactsetIdentifier)-[:IDENTIFIES]->(n)
 OPTIONAL MATCH (tme:TMEIdentifier)-[:IDENTIFIES]->(n)
-OPTIONAL MATCH (lei:LegalEntityIdentifier)-[:IDENTIFIES]->(n)
-return distinct n.uuid as uuid, n.prefLabel as prefLabel, labels(n) as types, {uuids:collect(distinct upp.value), TME:collect(distinct tme.value), factsetIdentifier:fs.value, leiCode:lei.value} as alternativeIdentifiers`,
+return distinct n.uuid as uuid, n.prefLabel as prefLabel, labels(n) as types, {uuids:collect(distinct upp.value), TME:collect(distinct tme.value)} as alternativeIdentifiers`,
 		Parameters: map[string]interface{}{
 			"uuid": uuid,
 		},

--- a/sections/sections_service.go
+++ b/sections/sections_service.go
@@ -92,16 +92,6 @@ func (s service) Write(thing interface{}) error {
 	queryBatch := []*neoism.CypherQuery{deletePreviousIdentifiersQuery, createSectionQuery}
 
 	//ADD all the IDENTIFIER nodes and IDENTIFIES relationships
-	if section.AlternativeIdentifiers.FactsetIdentifier != "" {
-		factsetIdentifierQuery := createNewIdentifierQuery(section.UUID, factsetIdentifierLabel, section.AlternativeIdentifiers.FactsetIdentifier)
-		queryBatch = append(queryBatch, factsetIdentifierQuery)
-	}
-
-	if section.AlternativeIdentifiers.LeiCode != "" {
-		leiCodeIdentifierQuery := createNewIdentifierQuery(section.UUID, leiIdentifierLabel, section.AlternativeIdentifiers.LeiCode)
-		queryBatch = append(queryBatch, leiCodeIdentifierQuery)
-	}
-
 	for _, alternativeUUID := range section.AlternativeIdentifiers.TME {
 		alternativeIdentifierQuery := createNewIdentifierQuery(section.UUID, tmeIdentifierLabel, alternativeUUID)
 		queryBatch = append(queryBatch, alternativeIdentifierQuery)

--- a/sections/sections_service.go
+++ b/sections/sections_service.go
@@ -20,10 +20,10 @@ func NewCypherSectionsService(cypherRunner neoutils.CypherRunner, indexManager n
 
 func (s service) Initialise() error {
 	return neoutils.EnsureConstraints(s.indexManager, map[string]string{
-		"Thing":   "uuid",
-		"Concept": "uuid",
-		"Classification": "uuid",
-		"Section":   "uuid",
+		"Thing":             "uuid",
+		"Concept":           "uuid",
+		"Classification":    "uuid",
+		"Section":           "uuid",
 		"FactsetIdentifier": "value",
 		"TMEIdentifier":     "value",
 		"UPPIdentifier":     "value"})
@@ -71,7 +71,7 @@ func (s service) Write(thing interface{}) error {
 			"uuid": section.UUID,
 		},
 	}
-	
+
 	//create-update node for SECTION
 	createSectionQuery := &neoism.CypherQuery{
 		Statement: `MERGE (n:Thing {uuid: {uuid}})

--- a/sections/sections_service_test.go
+++ b/sections/sections_service_test.go
@@ -14,8 +14,6 @@ const (
 	newSectionUUID       = "123456"
 	tmeID                = "TME_ID"
 	newTmeID             = "NEW_TME_ID"
-	fsetID               = "fset_ID"
-	leiCodeID            = "leiCode"
 	prefLabel            = "Test"
 	specialCharPrefLabel = "Test 'special chars"
 )
@@ -68,7 +66,7 @@ func TestCreateCompleteSectionWithPropsAndIdentifiers(t *testing.T) {
 	assert := assert.New(t)
 	sectionsDriver := getSectionsCypherDriver(t)
 
-	alternativeIdentifiers := alternativeIdentifiers{TME: []string{tmeID}, UUIDS: []string{sectionUUID}, FactsetIdentifier: fsetID, LeiCode: leiCodeID}
+	alternativeIdentifiers := alternativeIdentifiers{TME: []string{tmeID}, UUIDS: []string{sectionUUID}}
 	sectionToWrite := Section{UUID: sectionUUID, PrefLabel: prefLabel, AlternativeIdentifiers: alternativeIdentifiers}
 
 	assert.NoError(sectionsDriver.Write(sectionToWrite), "Failed to write section")
@@ -84,7 +82,7 @@ func TestUpdateWillRemovePropertiesAndIdentifiersNoLongerPresent(t *testing.T) {
 	assert := assert.New(t)
 	sectionsDriver := getSectionsCypherDriver(t)
 
-	allAlternativeIdentifiers := alternativeIdentifiers{TME: []string{}, UUIDS: []string{sectionUUID}, FactsetIdentifier: fsetID, LeiCode: leiCodeID}
+	allAlternativeIdentifiers := alternativeIdentifiers{TME: []string{}, UUIDS: []string{sectionUUID}}
 	sectionToWrite := Section{UUID: sectionUUID, PrefLabel: prefLabel, AlternativeIdentifiers: allAlternativeIdentifiers}
 
 	assert.NoError(sectionsDriver.Write(sectionToWrite), "Failed to write section")

--- a/sections/sections_service_test.go
+++ b/sections/sections_service_test.go
@@ -4,100 +4,158 @@ import (
 	"os"
 	"testing"
 
-	"github.com/Financial-Times/base-ft-rw-app-go/baseftrwapp"
 	"github.com/Financial-Times/neo-utils-go/neoutils"
 	"github.com/jmcvetta/neoism"
 	"github.com/stretchr/testify/assert"
 )
 
-var sectionsDriver baseftrwapp.Service
+const (
+	sectionUUID            = "12345"
+	newSectionUUID         = "123456"
+	tmeID                = "TME_ID"
+	newTmeID             = "NEW_TME_ID"
+	fsetID               = "fset_ID"
+	leiCodeID            = "leiCode"
+	prefLabel            = "Test"
+	specialCharPrefLabel = "Test 'special chars"
+)
 
-func TestDelete(t *testing.T) {
-	assert := assert.New(t)
-	uuid := "12345"
-
-	sectionsDriver = getSectionsCypherDriver(t)
-
-	sectionToDelete := Section{UUID: uuid, CanonicalName: "Test", TmeIdentifier: "TME_ID"}
-
-	assert.NoError(sectionsDriver.Write(sectionToDelete), "Failed to write section")
-
-	found, err := sectionsDriver.Delete(uuid)
-	assert.True(found, "Didn't manage to delete section for uuid %", uuid)
-	assert.NoError(err, "Error deleting section for uuid %s", uuid)
-
-	p, found, err := sectionsDriver.Read(uuid)
-
-	assert.Equal(Section{}, p, "Found section %s who should have been deleted", p)
-	assert.False(found, "Found section for uuid %s who should have been deleted", uuid)
-	assert.NoError(err, "Error trying to find section for uuid %s", uuid)
-}
-
-func TestCreateAllValuesPresent(t *testing.T) {
-	assert := assert.New(t)
-	uuid := "12345"
-	sectionsDriver = getSectionsCypherDriver(t)
-
-	sectionToWrite := Section{UUID: uuid, CanonicalName: "Test", TmeIdentifier: "TME_ID"}
-
-	assert.NoError(sectionsDriver.Write(sectionToWrite), "Failed to write section")
-
-	readSectionForUUIDAndCheckFieldsMatch(t, uuid, sectionToWrite)
-
-	cleanUp(t, uuid)
-}
-
-func TestCreateHandlesSpecialCharacters(t *testing.T) {
-	assert := assert.New(t)
-	uuid := "12345"
-	sectionsDriver = getSectionsCypherDriver(t)
-
-	sectionToWrite := Section{UUID: uuid, CanonicalName: "Test 'special chars", TmeIdentifier: "TME_ID"}
-
-	assert.NoError(sectionsDriver.Write(sectionToWrite), "Failed to write section")
-
-	readSectionForUUIDAndCheckFieldsMatch(t, uuid, sectionToWrite)
-
-	cleanUp(t, uuid)
-}
-
-func TestCreateNotAllValuesPresent(t *testing.T) {
-	assert := assert.New(t)
-	uuid := "12345"
-	sectionsDriver = getSectionsCypherDriver(t)
-
-	sectionToWrite := Section{UUID: uuid, CanonicalName: "Test"}
-
-	assert.NoError(sectionsDriver.Write(sectionToWrite), "Failed to write section")
-
-	readSectionForUUIDAndCheckFieldsMatch(t, uuid, sectionToWrite)
-
-	cleanUp(t, uuid)
-}
-
-func TestUpdateWillRemovePropertiesNoLongerPresent(t *testing.T) {
-	assert := assert.New(t)
-	uuid := "12345"
-	sectionsDriver = getSectionsCypherDriver(t)
-
-	sectionToWrite := Section{UUID: uuid, CanonicalName: "Test", TmeIdentifier: "TME_ID"}
-
-	assert.NoError(sectionsDriver.Write(sectionToWrite), "Failed to write section")
-	readSectionForUUIDAndCheckFieldsMatch(t, uuid, sectionToWrite)
-
-	updatedSection := Section{UUID: uuid, CanonicalName: "Test", TmeIdentifier: "TME_ID"}
-
-	assert.NoError(sectionsDriver.Write(updatedSection), "Failed to write updated section")
-	readSectionForUUIDAndCheckFieldsMatch(t, uuid, updatedSection)
-
-	cleanUp(t, uuid)
-}
+var defaultTypes = []string{"Thing", "Concept", "Classification", "Section"}
 
 func TestConnectivityCheck(t *testing.T) {
 	assert := assert.New(t)
-	sectionsDriver = getSectionsCypherDriver(t)
+	sectionsDriver := getSectionsCypherDriver(t)
 	err := sectionsDriver.Check()
 	assert.NoError(err, "Unexpected error on connectivity check")
+}
+
+func TestPrefLabelIsCorrectlyWritten(t *testing.T) {
+	assert := assert.New(t)
+	sectionsDriver := getSectionsCypherDriver(t)
+
+	alternativeIdentifiers := alternativeIdentifiers{UUIDS: []string{sectionUUID}}
+	sectionToWrite := Section{UUID: sectionUUID, PrefLabel: prefLabel, AlternativeIdentifiers: alternativeIdentifiers}
+
+	err := sectionsDriver.Write(sectionToWrite)
+	assert.NoError(err, "ERROR happened during write time")
+
+	storedSection, found, err := sectionsDriver.Read(sectionUUID)
+	assert.NoError(err, "ERROR happened during read time")
+	assert.Equal(true, found)
+	assert.NotEmpty(storedSection)
+
+	assert.Equal(prefLabel, storedSection.(Section).PrefLabel, "PrefLabel should be "+prefLabel)
+	cleanUp(assert, sectionUUID, sectionsDriver)
+}
+
+func TestPrefLabelSpecialCharactersAreHandledByCreate(t *testing.T) {
+	assert := assert.New(t)
+	sectionsDriver := getSectionsCypherDriver(t)
+
+	alternativeIdentifiers := alternativeIdentifiers{TME: []string{}, UUIDS: []string{sectionUUID}}
+	sectionToWrite := Section{UUID: sectionUUID, PrefLabel: specialCharPrefLabel, AlternativeIdentifiers: alternativeIdentifiers}
+
+	assert.NoError(sectionsDriver.Write(sectionToWrite), "Failed to write section")
+
+	//add default types that will be automatically added by the writer
+	sectionToWrite.Types = defaultTypes
+	//check if sectionToWrite is the same with the one inside the DB
+	readSectionForUUIDAndCheckFieldsMatch(assert, sectionsDriver, sectionUUID, sectionToWrite)
+	cleanUp(assert, sectionUUID, sectionsDriver)
+}
+
+func TestCreateCompleteSectionWithPropsAndIdentifiers(t *testing.T) {
+	assert := assert.New(t)
+	sectionsDriver := getSectionsCypherDriver(t)
+
+	alternativeIdentifiers := alternativeIdentifiers{TME: []string{tmeID}, UUIDS: []string{sectionUUID}, FactsetIdentifier: fsetID, LeiCode: leiCodeID}
+	sectionToWrite := Section{UUID: sectionUUID, PrefLabel: prefLabel, AlternativeIdentifiers: alternativeIdentifiers}
+
+	assert.NoError(sectionsDriver.Write(sectionToWrite), "Failed to write section")
+
+	//add default types that will be automatically added by the writer
+	sectionToWrite.Types = defaultTypes
+	//check if sectionToWrite is the same with the one inside the DB
+	readSectionForUUIDAndCheckFieldsMatch(assert, sectionsDriver, sectionUUID, sectionToWrite)
+	cleanUp(assert, sectionUUID, sectionsDriver)
+}
+
+func TestUpdateWillRemovePropertiesAndIdentifiersNoLongerPresent(t *testing.T) {
+	assert := assert.New(t)
+	sectionsDriver := getSectionsCypherDriver(t)
+
+	allAlternativeIdentifiers := alternativeIdentifiers{TME: []string{}, UUIDS: []string{sectionUUID}, FactsetIdentifier: fsetID, LeiCode: leiCodeID}
+	sectionToWrite := Section{UUID: sectionUUID, PrefLabel: prefLabel, AlternativeIdentifiers: allAlternativeIdentifiers}
+
+	assert.NoError(sectionsDriver.Write(sectionToWrite), "Failed to write section")
+	//add default types that will be automatically added by the writer
+	sectionToWrite.Types = defaultTypes
+	readSectionForUUIDAndCheckFieldsMatch(assert, sectionsDriver, sectionUUID, sectionToWrite)
+
+	tmeAlternativeIdentifiers := alternativeIdentifiers{TME: []string{tmeID}, UUIDS: []string{sectionUUID}}
+	updatedSection := Section{UUID: sectionUUID, PrefLabel: specialCharPrefLabel, AlternativeIdentifiers: tmeAlternativeIdentifiers}
+
+	assert.NoError(sectionsDriver.Write(updatedSection), "Failed to write updated section")
+	//add default types that will be automatically added by the writer
+	updatedSection.Types = defaultTypes
+	readSectionForUUIDAndCheckFieldsMatch(assert, sectionsDriver, sectionUUID, updatedSection)
+
+	cleanUp(assert, sectionUUID, sectionsDriver)
+}
+
+func TestDelete(t *testing.T) {
+	assert := assert.New(t)
+	sectionsDriver := getSectionsCypherDriver(t)
+
+	alternativeIdentifiers := alternativeIdentifiers{TME: []string{tmeID}, UUIDS: []string{sectionUUID}}
+	sectionToDelete := Section{UUID: sectionUUID, PrefLabel: prefLabel, AlternativeIdentifiers: alternativeIdentifiers}
+
+	assert.NoError(sectionsDriver.Write(sectionToDelete), "Failed to write section")
+
+	found, err := sectionsDriver.Delete(sectionUUID)
+	assert.True(found, "Didn't manage to delete section for uuid %", sectionUUID)
+	assert.NoError(err, "Error deleting section for uuid %s", sectionUUID)
+
+	p, found, err := sectionsDriver.Read(sectionUUID)
+
+	assert.Equal(Section{}, p, "Found section %s who should have been deleted", p)
+	assert.False(found, "Found section for uuid %s who should have been deleted", sectionUUID)
+	assert.NoError(err, "Error trying to find section for uuid %s", sectionUUID)
+}
+
+func TestCount(t *testing.T) {
+	assert := assert.New(t)
+	sectionsDriver := getSectionsCypherDriver(t)
+
+	alternativeIds := alternativeIdentifiers{TME: []string{tmeID}, UUIDS: []string{sectionUUID}}
+	sectionOneToCount := Section{UUID: sectionUUID, PrefLabel: prefLabel, AlternativeIdentifiers: alternativeIds}
+
+	assert.NoError(sectionsDriver.Write(sectionOneToCount), "Failed to write section")
+
+	nr, err := sectionsDriver.Count()
+	assert.Equal(1, nr, "Should be 1 sections in DB - count differs")
+	assert.NoError(err, "An unexpected error occurred during count")
+
+	newAlternativeIds := alternativeIdentifiers{TME: []string{newTmeID}, UUIDS: []string{newSectionUUID}}
+	sectionTwoToCount := Section{UUID: newSectionUUID, PrefLabel: specialCharPrefLabel, AlternativeIdentifiers: newAlternativeIds}
+
+	assert.NoError(sectionsDriver.Write(sectionTwoToCount), "Failed to write section")
+
+	nr, err = sectionsDriver.Count()
+	assert.Equal(2, nr, "Should be 2 sections in DB - count differs")
+	assert.NoError(err, "An unexpected error occurred during count")
+
+	cleanUp(assert, sectionUUID, sectionsDriver)
+	cleanUp(assert, newSectionUUID, sectionsDriver)
+}
+
+func readSectionForUUIDAndCheckFieldsMatch(assert *assert.Assertions, sectionsDriver service, uuid string, expectedSection Section) {
+
+	storedSection, found, err := sectionsDriver.Read(uuid)
+
+	assert.NoError(err, "Error finding section for uuid %s", uuid)
+	assert.True(found, "Didn't find section for uuid %s", uuid)
+	assert.Equal(expectedSection, storedSection, "sections should be the same")
 }
 
 func getSectionsCypherDriver(t *testing.T) service {
@@ -112,42 +170,7 @@ func getSectionsCypherDriver(t *testing.T) service {
 	return NewCypherSectionsService(neoutils.StringerDb{db}, db)
 }
 
-func readSectionForUUIDAndCheckFieldsMatch(t *testing.T, uuid string, expectedSection Section) {
-	assert := assert.New(t)
-	storedSection, found, err := sectionsDriver.Read(uuid)
-
-	assert.NoError(err, "Error finding section for uuid %s", uuid)
-	assert.True(found, "Didn't find section for uuid %s", uuid)
-	assert.Equal(expectedSection, storedSection, "sections should be the same")
-}
-
-func TestWritePrefLabelIsAlsoWrittenAndIsEqualToName(t *testing.T) {
-	assert := assert.New(t)
-	sectionsDriver := getSectionsCypherDriver(t)
-	uuid := "12345"
-	sectionToWrite := Section{UUID: uuid, CanonicalName: "Test", TmeIdentifier: "TME_ID"}
-
-	assert.NoError(sectionsDriver.Write(sectionToWrite), "Failed to write section")
-
-	result := []struct {
-		PrefLabel string `json:"t.prefLabel"`
-	}{}
-
-	getPrefLabelQuery := &neoism.CypherQuery{
-		Statement: `
-				MATCH (t:Section {uuid:"12345"}) RETURN t.prefLabel
-				`,
-		Result: &result,
-	}
-
-	err := sectionsDriver.cypherRunner.CypherBatch([]*neoism.CypherQuery{getPrefLabelQuery})
-	assert.NoError(err)
-	assert.Equal("Test", result[0].PrefLabel, "PrefLabel should be 'Test")
-	cleanUp(t, uuid)
-}
-
-func cleanUp(t *testing.T, uuid string) {
-	assert := assert.New(t)
+func cleanUp(assert *assert.Assertions, uuid string, sectionsDriver service) {
 	found, err := sectionsDriver.Delete(uuid)
 	assert.True(found, "Didn't manage to delete section for uuid %", uuid)
 	assert.NoError(err, "Error deleting section for uuid %s", uuid)

--- a/sections/sections_service_test.go
+++ b/sections/sections_service_test.go
@@ -10,8 +10,8 @@ import (
 )
 
 const (
-	sectionUUID            = "12345"
-	newSectionUUID         = "123456"
+	sectionUUID          = "12345"
+	newSectionUUID       = "123456"
 	tmeID                = "TME_ID"
 	newTmeID             = "NEW_TME_ID"
 	fsetID               = "fset_ID"


### PR DESCRIPTION
Changes include for the sections-rw-neo4j:
- Make all the alternative ids Identifier nodes
- Only use prefLabel
- Add build-info
- Update the RW for the new json model - coming out from the transformer
